### PR TITLE
Fix execline with-contenv paths and bump hotfix version

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.21
+version: 0.1.21-hotfix.1
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/services.d/bluetooth/run
+++ b/snapserver/rootfs/etc/services.d/bluetooth/run
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 echo "[BT] Starting bluetoothd" > /proc/1/fd/1
 exec /usr/lib/bluetooth/bluetoothd --noplugin=sap --nodetach

--- a/snapserver/rootfs/etc/services.d/dbus/run
+++ b/snapserver/rootfs/etc/services.d/dbus/run
@@ -1,3 +1,4 @@
-#!/usr/bin/execlineb -P
-with-contenv
+#!/command/execlineb -P
+/command/with-contenv
 dbus-daemon --system --nofork --nopidfile --nosyslog
+

--- a/snapserver/rootfs/etc/services.d/disable-dmsg/run
+++ b/snapserver/rootfs/etc/services.d/disable-dmsg/run
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 # Disable kernel logs to console
 exec dmesg --console-off

--- a/snapserver/rootfs/etc/services.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/services.d/pulseaudio/run
@@ -1,3 +1,4 @@
-#!/usr/bin/execlineb -P
-with-contenv
+#!/command/execlineb -P
+/command/with-contenv
 pulseaudio --exit-idle-time=-1 --system --disallow-exit --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
+

--- a/snapserver/rootfs/etc/services.d/setup/run
+++ b/snapserver/rootfs/etc/services.d/setup/run
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 sleep 2
 if ! pactl list short sinks | grep -q bt2snap; then
   pactl load-module module-pipe-sink file=/tmp/snapfifo format=s16le rate=44100 channels=2 sink_name=bt2snap


### PR DESCRIPTION
## Summary
- ensure execline-based services invoke /command/with-contenv from the new s6-overlay command path
- bump the add-on hotfix version to 0.1.21-hotfix.1 for release tracking

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c78c46a88333abc0f5dba7b0c0a6