### PR TITLE
Improve start logging for Snapserver add-on

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.22
+version: 0.1.23
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver


### PR DESCRIPTION
## Summary
- ensure the entrypoint runs under `with-contenv` and emit a visible start banner in the Supervisor logs
- rework the SnapServer logging pipeline to keep the shell alive, capture the exit status, and add a log reset marker
- bump the add-on version to 0.1.23

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7cd016c1083339e265bbdd9e2e767