### PR TITLE
Fix Snapserver startup under s6

### DIFF
--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -34,4 +34,4 @@ RUN \
 COPY run.sh /
 RUN chmod a+x /run.sh
 
-CMD [ "/run.sh" ]
+CMD [ "/init" ]

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.25
+version: 0.1.26
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/services.d/snapserver/run
+++ b/snapserver/rootfs/etc/services.d/snapserver/run
@@ -1,0 +1,3 @@
+#!/command/with-contenv bashio
+
+exec /run.sh


### PR DESCRIPTION
## Summary
- switch the container entrypoint to /init so the s6-overlay can bootstrap correctly
- add an s6 service that executes the existing run.sh startup logic
- bump the add-on version to 0.1.26

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7f52419708333a627d7d7a258a5b3