### PR TITLE
Disable init wrapper for Snapserver addon

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.26
+version: 0.1.27
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver
@@ -20,7 +20,7 @@ startup: services   # Startar tidigt, innan appar
 boot: auto          # Startar automatiskt vid boot
 map: ["share:rw"]
 audio: true
-init: true
+init: false
 options:
   streams: |
     spotify:///librespot?name=Spotify&bitrate=320


### PR DESCRIPTION
## Summary
- set `init` to false to avoid the s6-overlay suexec PID 1 error when running the addon
- bump the addon version to 0.1.27

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fab4040083339e71a8063592fd06