### PR TITLE
Fix service startup errors and bump add-on version

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.29
+version: 0.1.30
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/services.d/avahi/run
+++ b/snapserver/rootfs/etc/services.d/avahi/run
@@ -1,4 +1,16 @@
 #!/command/with-contenv bashio
 
+bashio::log.info "[Avahi] Waiting for system bus"
+for _ in $(seq 1 50); do
+    if [[ -S /var/run/dbus/system_bus_socket ]]; then
+        break
+    fi
+    sleep 0.1
+done
+
+if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
+    bashio::log.warning "[Avahi] system bus socket not available after waiting"
+fi
+
 bashio::log.info "[Avahi] Starting avahi-daemon"
-exec avahi-daemon --no-chroot --daemonize=false
+exec avahi-daemon --no-chroot --no-daemon

--- a/snapserver/rootfs/etc/services.d/bluetooth/run
+++ b/snapserver/rootfs/etc/services.d/bluetooth/run
@@ -1,4 +1,16 @@
 #!/command/with-contenv bashio
 
+bashio::log.info "[BT] Waiting for system bus"
+for _ in $(seq 1 50); do
+    if [[ -S /var/run/dbus/system_bus_socket ]]; then
+        break
+    fi
+    sleep 0.1
+done
+
+if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
+    bashio::log.warning "[BT] system bus socket not available after waiting"
+fi
+
 bashio::log.info "[BT] Starting bluetoothd"
 exec /usr/lib/bluetooth/bluetoothd --noplugin=sap --nodetach

--- a/snapserver/rootfs/etc/services.d/dbus/run
+++ b/snapserver/rootfs/etc/services.d/dbus/run
@@ -2,7 +2,11 @@
 
 bashio::log.info "[DBUS] Preparing runtime directory"
 mkdir -p /run/dbus
-ln -s /run/dbus /var/run/dbus 2>/dev/null || true
+
+if [[ ! -e /var/run/dbus ]]; then
+    mkdir -p /var/run
+    ln -s /run/dbus /var/run/dbus
+fi
 
 bashio::log.info "[DBUS] Starting system bus"
 exec dbus-daemon --system --nofork --nopidfile --nosyslog

--- a/snapserver/rootfs/etc/services.d/disable-dmsg/run
+++ b/snapserver/rootfs/etc/services.d/disable-dmsg/run
@@ -1,4 +1,8 @@
 #!/command/with-contenv bashio
 
 bashio::log.info "[dmesg] Reducing kernel console verbosity"
-exec dmesg -n 1
+if ! dmesg -n 1; then
+    bashio::log.warning "[dmesg] Unable to adjust kernel console verbosity"
+fi
+
+exit 0

--- a/snapserver/rootfs/etc/services.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/services.d/pulseaudio/run
@@ -5,6 +5,18 @@ mkdir -p /var/run/pulse/.config/pulse
 mkdir -p /run/pulse
 chown -R pulse:pulse /var/run/pulse /run/pulse || true
 
+bashio::log.info "[PA] Waiting for system bus"
+for _ in $(seq 1 50); do
+    if [[ -S /var/run/dbus/system_bus_socket ]]; then
+        break
+    fi
+    sleep 0.1
+done
+
+if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
+    bashio::log.warning "[PA] system bus socket not available after waiting"
+fi
+
 bashio::log.info "[PA] Starting PulseAudio"
 exec pulseaudio --exit-idle-time=-1 --system --disallow-exit --disallow-module-loading \
     --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa


### PR DESCRIPTION
## Summary
- ensure the D-Bus runtime directory is created safely before starting the system bus
- wait for the system bus before launching Bluetooth, PulseAudio, and Avahi services and adjust Avahi flags
- handle dmesg permission issues gracefully and bump the add-on version to 0.1.30

## Testing
- bash -n snapserver/rootfs/etc/services.d/dbus/run
- bash -n snapserver/rootfs/etc/services.d/bluetooth/run
- bash -n snapserver/rootfs/etc/services.d/pulseaudio/run
- bash -n snapserver/rootfs/etc/services.d/avahi/run
- bash -n snapserver/rootfs/etc/services.d/disable-dmsg/run

------
https://chatgpt.com/codex/tasks/task_e_68d8175216788333ac3983e1faa80420