### PR TITLE
Handle PulseAudio and bluetoothd startup conflicts

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.30
+version: 0.1.31
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/services.d/bluetooth/run
+++ b/snapserver/rootfs/etc/services.d/bluetooth/run
@@ -13,4 +13,9 @@ if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
 fi
 
 bashio::log.info "[BT] Starting bluetoothd"
+if pidof bluetoothd >/dev/null 2>&1; then
+    bashio::log.warning "[BT] Detected an existing bluetoothd process on the host. Skipping internal daemon startup."
+    exec tail -f /dev/null
+fi
+
 exec /usr/lib/bluetooth/bluetoothd --noplugin=sap --nodetach

--- a/snapserver/rootfs/etc/services.d/disable-dmsg/run
+++ b/snapserver/rootfs/etc/services.d/disable-dmsg/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 
 bashio::log.info "[dmesg] Reducing kernel console verbosity"
-if ! dmesg -n 1; then
+if ! dmesg -n 1 &>/dev/null; then
     bashio::log.warning "[dmesg] Unable to adjust kernel console verbosity"
 fi
 

--- a/snapserver/rootfs/etc/services.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/services.d/pulseaudio/run
@@ -5,6 +5,9 @@ mkdir -p /var/run/pulse/.config/pulse
 mkdir -p /run/pulse
 chown -R pulse:pulse /var/run/pulse /run/pulse || true
 
+export PULSE_RUNTIME_PATH="/var/run/pulse"
+export XDG_RUNTIME_DIR="/var/run/pulse"
+
 bashio::log.info "[PA] Waiting for system bus"
 for _ in $(seq 1 50); do
     if [[ -S /var/run/dbus/system_bus_socket ]]; then
@@ -16,7 +19,6 @@ done
 if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
     bashio::log.warning "[PA] system bus socket not available after waiting"
 fi
-
 bashio::log.info "[PA] Starting PulseAudio"
-exec pulseaudio --exit-idle-time=-1 --system --disallow-exit --disallow-module-loading \
+exec /command/s6-setuidgid pulse pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
     --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa

--- a/snapserver/rootfs/etc/services.d/setup/run
+++ b/snapserver/rootfs/etc/services.d/setup/run
@@ -1,23 +1,38 @@
 #!/command/with-contenv bashio
+
 sleep 2
 
-if [ ! -p /tmp/snapfifo ]; then
-  mkfifo /tmp/snapfifo
+export PULSE_RUNTIME_PATH="/var/run/pulse"
+export XDG_RUNTIME_DIR="/var/run/pulse"
+
+if [[ ! -p /tmp/snapfifo ]]; then
+    mkfifo /tmp/snapfifo
 fi
 
-if ! pactl list short sinks | grep -q bt_snapcast; then
-  pactl load-module module-null-sink sink_name=bt_snapcast sink_properties=device.description="Bluetooth->Snapcast"
-  pactl load-module module-pipe-sink sink=bt_snapcast file=/tmp/snapfifo format=s16le rate=44100 channels=2
+run_pactl() {
+    /command/s6-setuidgid pulse pactl "$@"
+}
+
+if ! run_pactl list short sinks | grep -q bt_snapcast; then
+    run_pactl load-module module-null-sink \
+        sink_name=bt_snapcast \
+        sink_properties=device.description="Bluetooth->Snapcast"
+    run_pactl load-module module-pipe-sink \
+        sink=bt_snapcast \
+        file=/tmp/snapfifo \
+        format=s16le \
+        rate=44100 \
+        channels=2
 fi
 
-pactl set-default-sink bt_snapcast
+run_pactl set-default-sink bt_snapcast
 
 controller=$(bluetoothctl list | head -n1 | awk '{print $2}')
-if [ -n "$controller" ]; then
-  bashio::log.info "[BT] Found controller: $controller"
-  echo -e "select $controller\npower on\nagent on\ndefault-agent\npairable on\ndiscoverable on" | bluetoothctl
+if [[ -n "${controller}" ]]; then
+    bashio::log.info "[BT] Found controller: ${controller}"
+    echo -e "select ${controller}\npower on\nagent on\ndefault-agent\npairable on\ndiscoverable on" | bluetoothctl
 else
-  bashio::log.warning "[BT] No Bluetooth controller detected yet"
+    bashio::log.warning "[BT] No Bluetooth controller detected yet"
 fi
 
 # Important: do not keep the process alive, exit immediately


### PR DESCRIPTION
## Summary
- run PulseAudio as the pulse user with a fixed runtime directory to avoid the s6 suexec crash
- guard the bluetoothd service so it does not clash with a host daemon and run pactl as pulse
- silence the noisy dmesg warning and bump the add-on version

## Testing
- bash -n snapserver/rootfs/etc/services.d/pulseaudio/run
- bash -n snapserver/rootfs/etc/services.d/setup/run
- bash -n snapserver/rootfs/etc/services.d/bluetooth/run
- bash -n snapserver/rootfs/etc/services.d/disable-dmsg/run

------
https://chatgpt.com/codex/tasks/task_e_68d81b68ae988333b199992e674fd3f8