### PR TITLE
Fix startup warnings and bump version to 0.1.32

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.31
+version: 0.1.32
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/services.d/avahi/run
+++ b/snapserver/rootfs/etc/services.d/avahi/run
@@ -13,4 +13,4 @@ if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
 fi
 
 bashio::log.info "[Avahi] Starting avahi-daemon"
-exec avahi-daemon --no-chroot --no-daemon
+exec avahi-daemon --no-chroot

--- a/snapserver/rootfs/etc/services.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/services.d/pulseaudio/run
@@ -7,6 +7,8 @@ chown -R pulse:pulse /var/run/pulse /run/pulse || true
 
 export PULSE_RUNTIME_PATH="/var/run/pulse"
 export XDG_RUNTIME_DIR="/var/run/pulse"
+export HOME="/var/run/pulse"
+export XDG_CONFIG_HOME="/var/run/pulse/.config"
 
 bashio::log.info "[PA] Waiting for system bus"
 for _ in $(seq 1 50); do


### PR DESCRIPTION
## Summary
- remove the unsupported --no-daemon flag from the Avahi service wrapper
- set PulseAudio HOME and XDG config paths to writable directories to avoid permission errors
- bump the add-on version to 0.1.32

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d81f64ba708333a755068993f394bf