### PR TITLE
Handle bluetoothd startup failures gracefully

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.32
+version: 0.1.33
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/services.d/bluetooth/run
+++ b/snapserver/rootfs/etc/services.d/bluetooth/run
@@ -18,4 +18,32 @@ if pidof bluetoothd >/dev/null 2>&1; then
     exec tail -f /dev/null
 fi
 
-exec /usr/lib/bluetooth/bluetoothd --noplugin=sap --nodetach
+cmd=(/usr/lib/bluetooth/bluetoothd --noplugin=sap --nodetach)
+"${cmd[@]}" &
+bt_pid=$!
+
+# Give the daemon a moment to fail fast (for example when another instance
+# already owns the Bluetooth resources on the host).
+sleep 1
+if ! kill -0 "${bt_pid}" 2>/dev/null; then
+    wait "${bt_pid}"
+    exit_code=$?
+    bashio::log.warning "[BT] bluetoothd failed to start (exit code: ${exit_code}). Continuing without the bundled daemon."
+    exec tail -f /dev/null
+fi
+
+terminate() {
+    local sig=${1:-TERM}
+    if kill -0 "${bt_pid}" 2>/dev/null; then
+        kill "-${sig}" "${bt_pid}"
+    fi
+}
+
+trap 'terminate TERM' TERM
+trap 'terminate INT' INT
+trap 'terminate QUIT' QUIT
+
+wait "${bt_pid}"
+exit_code=$?
+bashio::log.info "[BT] bluetoothd exited with code ${exit_code}"
+exit "${exit_code}"


### PR DESCRIPTION
## Summary
- keep the bluetooth service alive even if the bundled bluetoothd daemon cannot claim the host Bluetooth resources
- add signal handling and logging around the bluetoothd lifecycle for clearer diagnostics
- bump the add-on version to 0.1.33

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d824830890833393adb2800fa4699d