### PR TITLE
Fix PulseAudio startup without D-Bus session

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.35
+version: 0.1.36
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/services.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/services.d/pulseaudio/run
@@ -11,12 +11,17 @@ fi
 
 ln -sf /var/run/pulse/.config/pulse/cookie /var/run/pulse/.pulse-cookie
 
+chmod 600 /var/run/pulse/.config/pulse/cookie /var/run/pulse/.pulse-cookie 2>/dev/null || true
+
 chown -R pulse:pulse /var/run/pulse /run/pulse || true
 
 export PULSE_RUNTIME_PATH="/var/run/pulse"
 export XDG_RUNTIME_DIR="/var/run/pulse"
 export HOME="/var/run/pulse"
 export XDG_CONFIG_HOME="/var/run/pulse/.config"
+export PULSE_COOKIE="/var/run/pulse/.config/pulse/cookie"
+export DBUS_SYSTEM_BUS_ADDRESS="unix:path=/var/run/dbus/system_bus_socket"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SYSTEM_BUS_ADDRESS}"
 
 bashio::log.info "[PA] Waiting for system bus"
 for _ in $(seq 1 50); do

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -8,13 +8,21 @@ if [[ ! -p /tmp/snapfifo ]]; then
     mkfifo /tmp/snapfifo
 fi
 
+# Export environment variables that make PulseAudio and pactl behave in a
+# predictable headless manner.
+mkdir -p /var/run/pulse/.config/pulse
+export PULSE_RUNTIME_PATH="/var/run/pulse"
+export XDG_RUNTIME_DIR="/var/run/pulse"
+export HOME="/var/run/pulse"
+export XDG_CONFIG_HOME="/var/run/pulse/.config"
+export PULSE_COOKIE="/var/run/pulse/.config/pulse/cookie"
+export DBUS_SYSTEM_BUS_ADDRESS="unix:path=/var/run/dbus/system_bus_socket"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SYSTEM_BUS_ADDRESS}"
+
 configure_audio_stack() {
     local attempt
     local controller
     local pa_ready=false
-
-    export PULSE_RUNTIME_PATH="/var/run/pulse"
-    export XDG_RUNTIME_DIR="/var/run/pulse"
 
     bashio::log.info "[Setup] Waiting for PulseAudio to become available"
     for attempt in $(seq 1 50); do


### PR DESCRIPTION
## Summary
- export runtime, cookie, and D-Bus variables so PulseAudio and pactl run without a graphical session
- ensure generated PulseAudio cookie has the right permissions
- bump the add-on version to 0.1.36

## Testing
- bash -n snapserver/run.sh

------
https://chatgpt.com/codex/tasks/task_e_68d832b617f483338e67ecaa18a1079d