### PR TITLE
Update base image to 18.1.3

### DIFF
--- a/snapserver/build.yaml
+++ b/snapserver/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:16.3.2
-  amd64: ghcr.io/hassio-addons/base:16.3.2
-  armv7: ghcr.io/hassio-addons/base:16.3.2
-  i386: ghcr.io/hassio-addons/base:16.3.2
+  aarch64: ghcr.io/hassio-addons/base:18.1.3
+  amd64: ghcr.io/hassio-addons/base:18.1.3
+  armv7: ghcr.io/hassio-addons/base:18.1.3
+  i386: ghcr.io/hassio-addons/base:18.1.3
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.39
+version: 0.1.40
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver


### PR DESCRIPTION
## Summary
- update the add-on base image to ghcr.io/hassio-addons/base:18.1.3 for all architectures
- bump the add-on version to 0.1.40 to reflect the base image change

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8424e86588333b719ef76ee2e4551