### PR TITLE
Fix bashio initialization for disable-dmesg service

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.41
+version: 0.1.42
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/disable-dmesg/up
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/disable-dmesg/up
@@ -1,4 +1,9 @@
-#!/command/with-contenv bashio
+#!/command/with-contenv bash
+# shellcheck shell=bash
+
+# Load Bashio logging helpers.
+# shellcheck disable=SC1091
+source /usr/lib/bashio.sh
 
 bashio::log.info "[dmesg] Reducing kernel console verbosity"
 if ! dmesg -n 1 &>/dev/null; then

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -1,4 +1,9 @@
-#!/command/with-contenv bashio
+#!/command/with-contenv bash
+# shellcheck shell=bash
+
+# Load Bashio for logging helpers and Supervisor integration.
+# shellcheck disable=SC1091
+source /usr/lib/bashio.sh
 
 mkdir -p /share/snapfifo
 mkdir -p /share/snapcast


### PR DESCRIPTION
## Summary
- ensure the disable-dmesg oneshot script uses bash and sources bashio helpers
- update the main run.sh entrypoint to load bashio explicitly
- bump the add-on version to 0.1.42

## Testing
- bash -n snapserver/run.sh
- bash -n snapserver/rootfs/etc/s6-overlay/s6-rc.d/disable-dmesg/up

------
https://chatgpt.com/codex/tasks/task_e_68d847aaf420833383191672a4590328