### PR TITLE
Fix disable-dmesg oneshot script and bump add-on version

### DIFF
--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache \
 
 # Copy root filesystem with services
 COPY rootfs /
-RUN find /etc/s6-overlay/s6-rc.d -maxdepth 2 -type f -name run -exec chmod +x {} \;
+RUN find /etc/s6-overlay/s6-rc.d -maxdepth 2 -type f \( -name run -o -name up \) -exec chmod +x {} \;
 
 # Install Librespot (latest from edge/testing)
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ librespot

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.42
+version: 0.1.43
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/disable-dmesg/up
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/disable-dmesg/up
@@ -1,11 +1,6 @@
-#!/command/with-contenv bash
-# shellcheck shell=bash
+#!/command/with-contenv sh
 
-# Load Bashio logging helpers.
-# shellcheck disable=SC1091
-source /usr/lib/bashio.sh
-
-bashio::log.info "[dmesg] Reducing kernel console verbosity"
-if ! dmesg -n 1 &>/dev/null; then
-    bashio::log.warning "[dmesg] Unable to adjust kernel console verbosity"
+printf '%s\n' "[dmesg] Reducing kernel console verbosity"
+if ! dmesg -n 1 >/dev/null 2>&1; then
+    printf '%s\n' "[dmesg] Unable to adjust kernel console verbosity"
 fi


### PR DESCRIPTION
## Summary
- simplify the disable-dmesg oneshot to avoid sourcing bashio so it can execute on startup
- ensure both run and up scripts in the s6 definitions are marked executable during the image build
- bump the add-on version to 0.1.43

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d84a7e232883339e58dd5aa03ed803