### PR TITLE
Fix Snapserver startup without bashio dependency

### DIFF
--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache \
-        pulseaudio alsa-plugins-pulse bash \
+        pulseaudio alsa-plugins-pulse bash jq \
     && rm -fr \
         /tmp/*
 

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.43
+version: 0.1.44
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver


### PR DESCRIPTION
## Summary
- replace the Bashio helper calls with internal logging and configuration helpers that read /data/options.json via jq
- install jq in the add-on image so the new helper functions can parse the configuration
- bump the add-on version to 0.1.44 for the release

## Testing
- bash -n snapserver/run.sh

------
https://chatgpt.com/codex/tasks/task_e_68d8bce500948333b67dac88b888640d