### PR TITLE
Fix PulseAudio FIFO sink setup and allow DBus ownership

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.44
+version: 0.1.45
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/dbus-1/system.d/pulseaudio-system.conf
+++ b/snapserver/rootfs/etc/dbus-1/system.d/pulseaudio-system.conf
@@ -1,0 +1,14 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="pulse">
+    <allow own="org.PulseAudio1"/>
+    <allow send_destination="org.PulseAudio1"/>
+    <allow send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_interface="org.PulseAudio.ExtStreamRestore1"/>
+  </policy>
+  <policy context="default">
+    <deny own="org.PulseAudio1"/>
+  </policy>
+</busconfig>

--- a/snapserver/rootfs/etc/pulse/system.pa
+++ b/snapserver/rootfs/etc/pulse/system.pa
@@ -4,6 +4,15 @@
 load-module module-bluetooth-policy
 load-module module-bluetooth-discover
 
-# Create a virtual sink for Snapcast
-load-module module-null-sink sink_name=bt_snapcast sink_properties=device.description="Bluetooth->Snapcast"
-load-module module-pipe-sink sink=bt_snapcast file=/tmp/snapfifo format=s16le rate=44100 channels=2
+# Create a virtual sink for Snapcast that writes PCM data to the FIFO used by
+# Snapserver.  The pipe sink itself is exposed as the default sink so Bluetooth
+# audio routed by module-bluetooth-policy is captured automatically.
+load-module module-pipe-sink \
+    sink_name=bt_snapcast \
+    sink_properties=device.description="Bluetooth->Snapcast" \
+    file=/tmp/snapfifo \
+    format=s16le \
+    rate=44100 \
+    channels=2
+
+set-default-sink bt_snapcast

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/bluetooth/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/bluetooth/run
@@ -23,7 +23,7 @@ if [[ ! -d /sys/class/bluetooth ]] || ! compgen -G '/sys/class/bluetooth/hci*' >
     exec tail -f /dev/null
 fi
 
-disabled_plugins=(sap bap bass mcp vcp micp ccp csip)
+disabled_plugins=(sap bap bass mcp vcp micp ccp csip rfkill)
 plugin_arg="$(IFS=,; echo "${disabled_plugins[*]}")"
 
 cmd=(/usr/lib/bluetooth/bluetoothd --nodetach --noplugin="${plugin_arg}")

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -113,13 +113,9 @@ configure_audio_stack() {
         log_warning "[Setup] PulseAudio did not become ready within the expected time"
     else
         if ! /command/s6-setuidgid pulse pactl list short sinks | grep -q "\\<bt_snapcast\\>"; then
-            /command/s6-setuidgid pulse pactl load-module module-null-sink \\
-                sink_name=bt_snapcast \\
-                sink_properties=device.description="Bluetooth->Snapcast" || \\
-                log_warning "[Setup] Failed to load module-null-sink"
-
             /command/s6-setuidgid pulse pactl load-module module-pipe-sink \\
-                sink=bt_snapcast \\
+                sink_name=bt_snapcast \\
+                sink_properties=device.description="Bluetooth->Snapcast" \\
                 file=/tmp/snapfifo \\
                 format=s16le \\
                 rate=44100 \\


### PR DESCRIPTION
## Summary
- ensure the Snapcast FIFO sink is configured through module-pipe-sink and set as the default PulseAudio sink
- allow the PulseAudio service user to own org.PulseAudio1 on D-Bus and disable BlueZ's rfkill plugin to avoid startup errors
- bump the add-on version to 0.1.45

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8c602b9a083339b55fe2cbb03c6ad