### PR TITLE
Align sample format configuration with audio stack

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.44
+version: 0.1.45
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver
@@ -28,7 +28,7 @@ options:
   buffer: 1000
   codec: "flac"
   send_to_muted: "false"
-  sampleformat: "48000:16:2"
+  sampleformat: "44100:16:2"
   http_enabled: "true"
   tcp_enabled: "true"
   logging_enabled: "true"


### PR DESCRIPTION
## Summary
- align the default sample format with the Snapserver pipe stream configuration to avoid conflicting rates
- bump the add-on version to 0.1.45 to reflect the configuration change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c76651048333b2f9d35b0cbfe09c