### PR TITLE
Fix PulseAudio startup and modernize service scripts

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.45
+version: 0.1.46
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/pulse/system.pa
+++ b/snapserver/rootfs/etc/pulse/system.pa
@@ -7,12 +7,6 @@ load-module module-bluetooth-discover
 # Create a virtual sink for Snapcast that writes PCM data to the FIFO used by
 # Snapserver.  The pipe sink itself is exposed as the default sink so Bluetooth
 # audio routed by module-bluetooth-policy is captured automatically.
-load-module module-pipe-sink \
-    sink_name=bt_snapcast \
-    sink_properties=device.description="Bluetooth->Snapcast" \
-    file=/tmp/snapfifo \
-    format=s16le \
-    rate=44100 \
-    channels=2
+load-module module-pipe-sink sink_name=bt_snapcast sink_properties=device.description="Bluetooth->Snapcast" file=/tmp/snapfifo format=s16le rate=44100 channels=2
 
 set-default-sink bt_snapcast

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/avahi/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/avahi/run
@@ -1,6 +1,22 @@
-#!/command/with-contenv bashio
+#!/command/with-contenv bash
 
-bashio::log.info "[Avahi] Waiting for system bus"
+set -euo pipefail
+
+log() {
+    local level="$1"
+    shift
+    printf '[%s] %s\n' "$level" "$*"
+}
+
+log_info() {
+    log "INFO" "$@"
+}
+
+log_warning() {
+    log "WARN" "$@"
+}
+
+log_info "[Avahi] Waiting for system bus"
 for _ in $(seq 1 50); do
     if [[ -S /var/run/dbus/system_bus_socket ]]; then
         break
@@ -9,8 +25,8 @@ for _ in $(seq 1 50); do
 done
 
 if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
-    bashio::log.warning "[Avahi] system bus socket not available after waiting"
+    log_warning "[Avahi] system bus socket not available after waiting"
 fi
 
-bashio::log.info "[Avahi] Starting avahi-daemon"
+log_info "[Avahi] Starting avahi-daemon"
 exec avahi-daemon --no-chroot

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/bluetooth/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/bluetooth/run
@@ -1,6 +1,22 @@
-#!/command/with-contenv bashio
+#!/command/with-contenv bash
 
-bashio::log.info "[BT] Waiting for system bus"
+set -euo pipefail
+
+log() {
+    local level="$1"
+    shift
+    printf '[%s] %s\n' "$level" "$*"
+}
+
+log_info() {
+    log "INFO" "$@"
+}
+
+log_warning() {
+    log "WARN" "$@"
+}
+
+log_info "[BT] Waiting for system bus"
 for _ in $(seq 1 50); do
     if [[ -S /var/run/dbus/system_bus_socket ]]; then
         break
@@ -9,17 +25,17 @@ for _ in $(seq 1 50); do
 done
 
 if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
-    bashio::log.warning "[BT] system bus socket not available after waiting"
+    log_warning "[BT] system bus socket not available after waiting"
 fi
 
-bashio::log.info "[BT] Starting bluetoothd"
+log_info "[BT] Starting bluetoothd"
 if pidof bluetoothd >/dev/null 2>&1; then
-    bashio::log.warning "[BT] Detected an existing bluetoothd process on the host. Skipping internal daemon startup."
+    log_warning "[BT] Detected an existing bluetoothd process on the host. Skipping internal daemon startup."
     exec tail -f /dev/null
 fi
 
 if [[ ! -d /sys/class/bluetooth ]] || ! compgen -G '/sys/class/bluetooth/hci*' >/dev/null; then
-    bashio::log.warning "[BT] No Bluetooth kernel interfaces detected. Skipping internal daemon startup."
+    log_warning "[BT] No Bluetooth kernel interfaces detected. Skipping internal daemon startup."
     exec tail -f /dev/null
 fi
 
@@ -34,9 +50,9 @@ bt_pid=$!
 # already owns the Bluetooth resources on the host).
 sleep 1
 if ! kill -0 "${bt_pid}" 2>/dev/null; then
-    wait "${bt_pid}"
+    wait "${bt_pid}" || true
     exit_code=$?
-    bashio::log.warning "[BT] bluetoothd failed to start (exit code: ${exit_code}). Continuing without the bundled daemon."
+    log_warning "[BT] bluetoothd failed to start (exit code: ${exit_code}). Continuing without the bundled daemon."
     exec tail -f /dev/null
 fi
 
@@ -51,7 +67,10 @@ trap 'terminate TERM' TERM
 trap 'terminate INT' INT
 trap 'terminate QUIT' QUIT
 
+set +e
 wait "${bt_pid}"
 exit_code=$?
-bashio::log.info "[BT] bluetoothd exited with code ${exit_code}"
+set -e
+
+log_info "[BT] bluetoothd exited with code ${exit_code}"
 exit "${exit_code}"

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/dbus/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/dbus/run
@@ -1,6 +1,22 @@
-#!/command/with-contenv bashio
+#!/command/with-contenv bash
 
-bashio::log.info "[DBUS] Preparing runtime directory"
+set -euo pipefail
+
+log() {
+    local level="$1"
+    shift
+    printf '[%s] %s\n' "$level" "$*"
+}
+
+log_info() {
+    log "INFO" "$@"
+}
+
+log_warning() {
+    log "WARN" "$@"
+}
+
+log_info "[DBUS] Preparing runtime directory"
 mkdir -p /run/dbus
 
 if [[ ! -e /var/run/dbus ]]; then
@@ -8,5 +24,5 @@ if [[ ! -e /var/run/dbus ]]; then
     ln -s /run/dbus /var/run/dbus
 fi
 
-bashio::log.info "[DBUS] Starting system bus"
+log_info "[DBUS] Starting system bus"
 exec dbus-daemon --system --nofork --nopidfile --nosyslog

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
@@ -1,6 +1,22 @@
-#!/command/with-contenv bashio
+#!/command/with-contenv bash
 
-bashio::log.info "[PA] Preparing runtime directories"
+set -euo pipefail
+
+log() {
+    local level="$1"
+    shift
+    printf '[%s] %s\n' "$level" "$*"
+}
+
+log_info() {
+    log "INFO" "$@"
+}
+
+log_warning() {
+    log "WARN" "$@"
+}
+
+log_info "[PA] Preparing runtime directories"
 mkdir -p /var/run/pulse/.config/pulse
 mkdir -p /run/pulse
 mkdir -p /etc/pulse/system.pa.d
@@ -23,7 +39,7 @@ export PULSE_COOKIE="/var/run/pulse/.config/pulse/cookie"
 export DBUS_SYSTEM_BUS_ADDRESS="unix:path=/var/run/dbus/system_bus_socket"
 export DBUS_SESSION_BUS_ADDRESS="${DBUS_SYSTEM_BUS_ADDRESS}"
 
-bashio::log.info "[PA] Waiting for system bus"
+log_info "[PA] Waiting for system bus"
 for _ in $(seq 1 50); do
     if [[ -S /var/run/dbus/system_bus_socket ]]; then
         break
@@ -32,8 +48,9 @@ for _ in $(seq 1 50); do
 done
 
 if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
-    bashio::log.warning "[PA] system bus socket not available after waiting"
+    log_warning "[PA] system bus socket not available after waiting"
 fi
-bashio::log.info "[PA] Starting PulseAudio"
+
+log_info "[PA] Starting PulseAudio"
 exec /command/s6-setuidgid pulse pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
     --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/snapserver/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/snapserver/run
@@ -1,3 +1,3 @@
-#!/command/with-contenv bashio
+#!/command/with-contenv bash
 
 exec /run.sh


### PR DESCRIPTION
## Summary
- replace bashio-dependent service scripts with plain bash helpers and explicit logging
- keep bluetooth, dbus, avahi, pulseaudio, and snapserver services compatible with current base image tooling
- fix PulseAudio pipe sink configuration and bump the add-on version to 0.1.46

## Testing
- bash -n snapserver/run.sh
- bash -n snapserver/rootfs/etc/s6-overlay/s6-rc.d/dbus/run
- bash -n snapserver/rootfs/etc/s6-overlay/s6-rc.d/avahi/run
- bash -n snapserver/rootfs/etc/s6-overlay/s6-rc.d/bluetooth/run
- bash -n snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
- bash -n snapserver/rootfs/etc/s6-overlay/s6-rc.d/snapserver/run

------
https://chatgpt.com/codex/tasks/task_e_68d8cb4de7808333a4b0feec9a48bc1b