### PR TITLE
Fix legacy service handling and PulseAudio FIFO permissions

### DIFF
--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache \
-        pulseaudio alsa-plugins-pulse bash jq \
+        pulseaudio alsa-plugins-pulse bash jq nss-mdns \
     && rm -fr \
         /tmp/*
 

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.46
+version: 0.1.47
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/type
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/type
@@ -1,0 +1,1 @@
+oneshot

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/up
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/up
@@ -1,0 +1,3 @@
+#!/command/with-contenv sh
+
+printf '%s\n' "[legacy] Skipping deprecated legacy service supervision"

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -81,8 +81,11 @@ mkdir -p /share/snapcast
 
 # Ensure that the FIFO used by PulseAudio exists so Snapserver can attach to it.
 if [[ ! -p /tmp/snapfifo ]]; then
-    mkfifo /tmp/snapfifo
+    mkfifo -m 0660 /tmp/snapfifo
+else
+    chmod 0660 /tmp/snapfifo || true
 fi
+chown pulse:pulse /tmp/snapfifo 2>/dev/null || true
 
 # Export environment variables that make PulseAudio and pactl behave in a
 # predictable headless manner.


### PR DESCRIPTION
## Summary
- add nss-mdns to the base image to restore Avahi NSS support
- replace the crashing legacy-services shim and fix the snapfifo permissions for PulseAudio
- bump the add-on version to 0.1.47

## Testing
- bash -n snapserver/run.sh

------
https://chatgpt.com/codex/tasks/task_e_68d8d0340b308333b7e3ea4dd52040e0