### PR TITLE
Remove unavailable nss-mdns package and bump version

### DIFF
--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache \
-        pulseaudio alsa-plugins-pulse bash jq nss-mdns \
+        pulseaudio alsa-plugins-pulse bash jq \
     && rm -fr \
         /tmp/*
 

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.47
+version: 0.1.48
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver


### PR DESCRIPTION
## Summary
- remove the nss-mdns package from the build to match Alpine 3.22 repositories
- bump the add-on version to 0.1.48

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8d3f7b91c8333a5c97bb453d50a67