### PR TITLE
Fix duplicate legacy service definition

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.48
+version: 0.1.49
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/type
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/type
@@ -1,1 +1,0 @@
-oneshot

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/up
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/up
@@ -1,3 +1,0 @@
-#!/command/with-contenv sh
-
-printf '%s\n' "[legacy] Skipping deprecated legacy service supervision"


### PR DESCRIPTION
## Summary
- remove the redundant legacy-services oneshot that now ships with s6-overlay 3.2.1.0 to resolve the duplicate definition error
- bump the add-on version to 0.1.49

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8d7ad16908333a20f47e295ba72d8