### PR TITLE
Fix PulseAudio startup under s6-overlay v3

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.53
+version: 0.1.54
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
@@ -52,8 +52,9 @@ if [[ ! -S /var/run/dbus/system_bus_socket ]]; then
 fi
 
 log_info "[PA] Starting PulseAudio"
-if command -v su-exec >/dev/null 2>&1; then
-    exec su-exec pulse pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
+if command -v setpriv >/dev/null 2>&1; then
+    exec setpriv --reuid pulse --regid pulse --init-groups \
+        pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
         --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
 fi
 


### PR DESCRIPTION
## Summary
- replace the PulseAudio service's su-exec usage with setpriv/runuser fallbacks that work with the updated base image
- bump the add-on version to 0.1.54

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9113d3c8083339342292366a8504c