### PR TITLE
Fix Alpine repo pinning and librespot install path

### DIFF
--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BUILD_FROM}
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG ALPINE_VERSION=3.21
+ARG ALPINE_VERSION=3.22
 ARG ALPINE_REPO_BASE=https://dl-cdn.alpinelinux.org/alpine
 
 # hadolint ignore=DL3003
@@ -54,10 +54,10 @@ RUN \
         pulseaudio-dev \
     && cargo install \
         --locked \
-        --root /usr \
+        --root /usr/local \
         --version "${LIBRESPOT_VERSION}" \
         librespot \
-    && strip /usr/bin/librespot \
+    && strip /usr/local/bin/librespot \
     && apk del .build-deps \
     && rm -rf \
         /root/.cache \

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.57
+version: 0.1.58
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver


### PR DESCRIPTION
## Summary
- update the pinned Alpine repository version to match the base image and avoid openssl conflicts
- install librespot into /usr/local and strip the binary in its new location
- bump the add-on version to 0.1.58

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68decc1c88708333a217d4dd4972b74c