### PR TITLE
Fix Alpine SSL conflict during build

### DIFF
--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -12,6 +12,12 @@ ARG ALPINE_REPO_BASE=https://dl-cdn.alpinelinux.org/alpine
 RUN \
     ALPINE_MAIN_REPO="${ALPINE_REPO_BASE}/v${ALPINE_VERSION}/main" && \
     ALPINE_COMMUNITY_REPO="${ALPINE_REPO_BASE}/v${ALPINE_VERSION}/community" && \
+    apk upgrade --no-cache \
+        --repository="${ALPINE_MAIN_REPO}" \
+        --repository="${ALPINE_COMMUNITY_REPO}" \
+        libcrypto3 \
+        libssl3 \
+        openssl && \
     apk add --no-cache \
         --repository="${ALPINE_MAIN_REPO}" \
         --repository="${ALPINE_COMMUNITY_REPO}" \

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.58
+version: 0.1.59
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver


### PR DESCRIPTION
## Summary
- update the Dockerfile to upgrade OpenSSL libraries before installing packages to avoid repository version conflicts
- bump the add-on version to 0.1.59

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dedd3d6c108333918df28644b92eee