### PR TITLE
Fix Alpine openssl conflict

### DIFF
--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -10,6 +10,11 @@ ARG ALPINE_REPO_BASE=https://dl-cdn.alpinelinux.org/alpine
 # hadolint ignore=DL3003
 # Pin the Alpine repositories to avoid intermittent BAD archive errors from upstream mirrors.
 RUN \
+    for package in libcrypto3 libssl3 openssl; do \
+        if grep -q "^${package}=" /etc/apk/world; then \
+            sed -i "s/^${package}=.*/${package}/" /etc/apk/world; \
+        fi; \
+    done && \
     ALPINE_MAIN_REPO="${ALPINE_REPO_BASE}/v${ALPINE_VERSION}/main" && \
     ALPINE_COMMUNITY_REPO="${ALPINE_REPO_BASE}/v${ALPINE_VERSION}/community" && \
     apk upgrade --no-cache \

--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.60
+version: 0.1.61
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver


### PR DESCRIPTION
## Summary
- clear version pins for OpenSSL-related packages before running apk upgrade to avoid libcrypto conflicts
- bump addon version to 0.1.61

## Testing
- not run (container lacks Docker)


------
https://chatgpt.com/codex/tasks/task_e_68dee1ec7b388333bedf5d8c04b29472