### PR TITLE
Fix legacy services shim for s6-overlay v3

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.61
+version: 0.1.62
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/type
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/type
@@ -1,1 +1,1 @@
-bundle
+oneshot

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/up
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/up
@@ -1,0 +1,7 @@
+#!/command/with-contenv sh
+
+# The services within this add-on are implemented with native s6-rc entries.
+# Keep the legacy shim in a no-op state so the supervisor doesn't attempt to
+# launch the deprecated services.d tree.
+printf '%s\n' "[INFO] [s6] legacy services shim disabled"
+exit 0


### PR DESCRIPTION
## Summary
- convert the legacy-services shim into a no-op oneshot so it no longer triggers s6-overlay failures
- bump the add-on version to 0.1.62

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1028c80fc833388f5146b08446c84