### PR TITLE
Fix duplicate legacy s6 service definition

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.62
+version: 0.1.63
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/down
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/down
@@ -1,1 +1,0 @@
-# Keep the legacy services shim disabled; all services use native s6-rc definitions.

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/type
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/type
@@ -1,1 +1,0 @@
-oneshot

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/up
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/legacy-services/up
@@ -1,7 +1,0 @@
-#!/command/with-contenv sh
-
-# The services within this add-on are implemented with native s6-rc entries.
-# Keep the legacy shim in a no-op state so the supervisor doesn't attempt to
-# launch the deprecated services.d tree.
-printf '%s\n' "[INFO] [s6] legacy services shim disabled"
-exit 0


### PR DESCRIPTION
## Summary
- remove the add-on specific legacy-services shim that conflicted with the base image
- bump the add-on version to 0.1.63

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e109018bfc8333b38f3c9a2e15ad29