### PR TITLE
Fix Snapserver startup by avoiding su-exec fallback

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.63
+version: 0.1.64
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
@@ -63,6 +63,12 @@ if command -v runuser >/dev/null 2>&1; then
         --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
 fi
 
+if command -v s6-applyuidgid >/dev/null 2>&1; then
+    exec s6-applyuidgid -u pulse -g pulse -- \
+        pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
+        --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
+fi
+
 # As a last resort, run PulseAudio as root so the service can still start.
 exec pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
     --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -83,13 +83,9 @@ run_as_pulse() {
         return $?
     fi
 
-    if command -v su-exec >/dev/null 2>&1; then
-        if su-exec pulse "$@"; then
-            return 0
-        fi
-
-        local status=$?
-        log_warning "su-exec failed with status ${status}; running command as root instead"
+    if command -v s6-applyuidgid >/dev/null 2>&1; then
+        s6-applyuidgid -u pulse -g pulse -- "$@"
+        return $?
     fi
 
     "$@"


### PR DESCRIPTION
## Summary
- avoid the s6-overlay su-exec helper when dropping to the pulse user and use s6-applyuidgid instead
- add the same fallback for the PulseAudio service script so it can start without setpriv/runuser
- bump the add-on version to 0.1.64

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1207f131c8333861e701e57404956