### PR TITLE
Fix PulseAudio startup under s6-overlay

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.64
+version: 0.1.65
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
@@ -63,9 +63,8 @@ if command -v runuser >/dev/null 2>&1; then
         --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
 fi
 
-if command -v s6-applyuidgid >/dev/null 2>&1; then
-    exec s6-applyuidgid -u pulse -g pulse -- \
-        pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
+if command -v su-exec >/dev/null 2>&1; then
+    exec su-exec pulse:pulse pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
         --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
 fi
 

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -83,8 +83,8 @@ run_as_pulse() {
         return $?
     fi
 
-    if command -v s6-applyuidgid >/dev/null 2>&1; then
-        s6-applyuidgid -u pulse -g pulse -- "$@"
+    if command -v su-exec >/dev/null 2>&1; then
+        su-exec pulse:pulse "$@"
         return $?
     fi
 


### PR DESCRIPTION
## Summary
- prefer `su-exec` when dropping to the pulse user so we no longer trigger `s6-overlay-suexec`
- bump the add-on version to 0.1.65

## Testing
- not run (add-on environment not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68e124b8aea48333b001826f7d48d27d