### PR TITLE
Fix pulse user helper for s6 overlay v3

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.65
+version: 0.1.66
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -83,6 +83,16 @@ run_as_pulse() {
         return $?
     fi
 
+    if command -v s6-setuidgid >/dev/null 2>&1; then
+        s6-setuidgid pulse "$@"
+        return $?
+    fi
+
+    if command -v s6-applyuidgid >/dev/null 2>&1; then
+        s6-applyuidgid -u pulse -g pulse -- "$@"
+        return $?
+    fi
+
     if command -v su-exec >/dev/null 2>&1; then
         su-exec pulse:pulse "$@"
         return $?


### PR DESCRIPTION
## Summary
- extend the run_as_pulse helper to prefer s6 overlay tools before falling back to su-exec
- bump the add-on version to 0.1.66

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e12c022bd08333a1a879fbffeac45b