### PR TITLE
Fix pulse helper and bump version to 0.1.67

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.66
+version: 0.1.67
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -83,6 +83,13 @@ run_as_pulse() {
         return $?
     fi
 
+    # Prefer su-exec before the s6 helpers; s6-overlay v3 limits suexec to PID 1
+    # which makes those commands unusable from inside the add-on runtime.
+    if command -v su-exec >/dev/null 2>&1; then
+        su-exec pulse:pulse "$@"
+        return $?
+    fi
+
     if command -v s6-setuidgid >/dev/null 2>&1; then
         s6-setuidgid pulse "$@"
         return $?
@@ -90,11 +97,6 @@ run_as_pulse() {
 
     if command -v s6-applyuidgid >/dev/null 2>&1; then
         s6-applyuidgid -u pulse -g pulse -- "$@"
-        return $?
-    fi
-
-    if command -v su-exec >/dev/null 2>&1; then
-        su-exec pulse:pulse "$@"
         return $?
     fi
 


### PR DESCRIPTION
## Summary
- ensure su-exec is preferred over s6 helpers when running commands as the pulse user to avoid s6-overlay suexec failures
- bump the add-on version to 0.1.67

## Testing
- bash -n snapserver/run.sh

------
https://chatgpt.com/codex/tasks/task_e_68e137e0bf6083339faf1c97b397b586