### PR TITLE
Avoid su-exec when running Snapserver as a service

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.69
+version: 0.1.70
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -83,14 +83,16 @@ run_as_pulse() {
         return $?
     fi
 
-    if command -v su-exec >/dev/null 2>&1; then
-        su-exec pulse:pulse "$@"
+    if command -v s6-setuidgid >/dev/null 2>&1; then
+        s6-setuidgid pulse "$@"
         return $?
     fi
 
-    # Note: s6-setuidgid and s6-applyuidgid are not used here to avoid
-    # dependencies on s6-overlay-specific commands in the main run script.
-    # This allows the script to work with standard user-switching tools.
+    # Note: su-exec (provided by s6-overlay as s6-overlay-suexec) can only be
+    # invoked by PID 1.  Since this script runs as a regular service when the
+    # add-on is started with init: true, falling back to su-exec would abort the
+    # service.  Therefore we intentionally avoid it here and rely on more
+    # generally available tooling instead.
 
     "$@"
 }


### PR DESCRIPTION
## Summary
- replace the su-exec fallback in run.sh with s6-setuidgid to avoid s6-overlay-suexec crashes when init services are enabled
- bump the add-on version to 0.1.70

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1519d3da08333932972e6ff61943e