### PR TITLE
Disable init and avoid su-exec for pulseaudio

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.70
+version: 0.1.71
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver
@@ -20,7 +20,7 @@ startup: services   # Starts early, before apps
 boot: auto          # Starts automatically at boot
 map: ["share:rw"]
 audio: true
-init: true
+init: false
 options:
   streams: |
     spotify:///librespot?name=Spotify&bitrate=320

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
@@ -63,8 +63,8 @@ if command -v runuser >/dev/null 2>&1; then
         --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
 fi
 
-if command -v su-exec >/dev/null 2>&1; then
-    exec su-exec pulse:pulse pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
+if command -v s6-setuidgid >/dev/null 2>&1; then
+    exec s6-setuidgid pulse pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
         --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
 fi
 


### PR DESCRIPTION
## Summary
- disable the add-on init system again and bump the version to 0.1.71
- replace the PulseAudio su-exec invocation with s6-setuidgid to avoid PID 1 restrictions

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e15ceaa3b883339ded1220ea2a9608