### PR TITLE
Fix privilege drop helpers for SnapServer add-on

### DIFF
--- a/snapserver/config.yaml
+++ b/snapserver/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Snapcast Server (Andreas fork)
-version: 0.1.71
+version: 0.1.72
 slug: snapcastserver_andreas
 description: "Snapcast server with bluetooth input"
 url: https://github.com/AndreasNorefalk/addon-snapserver

--- a/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
+++ b/snapserver/rootfs/etc/s6-overlay/s6-rc.d/pulseaudio/run
@@ -63,11 +63,6 @@ if command -v runuser >/dev/null 2>&1; then
         --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
 fi
 
-if command -v s6-setuidgid >/dev/null 2>&1; then
-    exec s6-setuidgid pulse pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
-        --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa
-fi
-
-# As a last resort, run PulseAudio as root so the service can still start.
+log_warning "[PA] Falling back to running PulseAudio as root"
 exec pulseaudio --exit-idle-time=-1 --disallow-exit --disallow-module-loading \
     --log-target=stderr --daemonize=no -nF /etc/pulse/system.pa

--- a/snapserver/run.sh
+++ b/snapserver/run.sh
@@ -73,27 +73,17 @@ config_has_value() {
 }
 
 run_as_pulse() {
-    if command -v runuser >/dev/null 2>&1; then
-        runuser -u pulse -- "$@"
-        return $?
-    fi
-
     if command -v setpriv >/dev/null 2>&1; then
         setpriv --reuid pulse --regid pulse --init-groups "$@"
         return $?
     fi
 
-    if command -v s6-setuidgid >/dev/null 2>&1; then
-        s6-setuidgid pulse "$@"
+    if command -v runuser >/dev/null 2>&1; then
+        runuser -u pulse -- "$@"
         return $?
     fi
 
-    # Note: su-exec (provided by s6-overlay as s6-overlay-suexec) can only be
-    # invoked by PID 1.  Since this script runs as a regular service when the
-    # add-on is started with init: true, falling back to su-exec would abort the
-    # service.  Therefore we intentionally avoid it here and rely on more
-    # generally available tooling instead.
-
+    log_warning "[Setup] Unable to drop privileges; running command as root: $1"
     "$@"
 }
 


### PR DESCRIPTION
## Summary
- avoid using s6-overlay specific helpers when dropping privileges so the services can start under s6-rc
- warn and run the PulseAudio service as root only when no privilege dropping tools are available
- bump the add-on version to 0.1.72

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e16e11fbdc8333aa96011c89dcff29